### PR TITLE
chore: Fix Product images being overlapped on Safari

### DIFF
--- a/src/features/product/ProductImageSwitcher.tsx
+++ b/src/features/product/ProductImageSwitcher.tsx
@@ -18,7 +18,7 @@ export function ProductImageSwitcher(props: ProductImageSwitcherProps) {
 
 	return (
 		<div class="flex aspect-[10/9] items-stretch gap-2">
-			<div class="relative flex flex-col gap-[inherit] overflow-hidden will-change-scroll">
+			<div class="relative flex flex-shrink-0 flex-col gap-[inherit] overflow-hidden will-change-scroll">
 				<For each={props.productImages}>
 					{(image, index) => (
 						<button


### PR DESCRIPTION
Tiny fix - 

https://github.com/user-attachments/assets/9ee02078-5c37-40a7-b8bb-9696d7f2b9da

