### PR TITLE
fix(components): remove `undefined` class

### DIFF
--- a/src/components/layout/SiteHeader.astro
+++ b/src/components/layout/SiteHeader.astro
@@ -10,7 +10,7 @@ const { class: className, ...props } = Astro.props;
 
 <nav
 	aria-label="Site navigation"
-	class={`min-h-20 !flex items-center flex-row md:justify-between py-2 bg-white ${className}`}
+	class:list={["min-h-20 !flex items-center flex-row md:justify-between py-2 bg-white", className]}
 	{...props}
 >
 	<div class="flex-1">

--- a/src/components/ui/ExternalLink.astro
+++ b/src/components/ui/ExternalLink.astro
@@ -9,6 +9,6 @@ const { target = '_blank', rel = 'noopener noreferrer', class: className, ...pro
 <a
 	target={target}
 	rel={rel}
-	class={`underline underline-offset-2 hover:no-underline ${className}`}
+	class:list={["underline underline-offset-2 hover:no-underline", className]}
 	{...props}><slot /></a
 >


### PR DESCRIPTION
Fixed a bug where `undefined` was appended to the class string if class was not explicitly passed.